### PR TITLE
No need to disable CLI Remoting anymore. It has been removed in 2.165

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@
 ##
 
 language: python
-python: "2.7"
+python: "2.7.15"
 
 # The tests will be run in Docker containers, to verify compatibility with
 # various OSes.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -122,14 +122,6 @@
       import hudson.*;
       import hudson.model.*;
 
-      // Disable CLI remoting, as its insecure and Jenkins yells about it.
-      // Reference: <://support.cloudbees.com/hc/en-us/articles/234709648-Disable-Jenkins-CLI>
-      if (Jenkins.instance.getDescriptor("jenkins.CLI").get().isEnabled()) {
-        Jenkins.instance.getDescriptor("jenkins.CLI").get().setEnabled(false)
-        Jenkins.instance.save()
-        println "Changed CLI remoting: now disabled."
-      }
-
       // Disable deprecated agent protocols.
       // Reference: <https://github.com/jenkinsci/jenkins/commit/efdd52e9e78cc057ea49a7d338ee575d131c1959>
       def agentProtocolWasDisabled = false

--- a/test/pre-test.sh
+++ b/test/pre-test.sh
@@ -18,7 +18,7 @@ fi
 
 # Create and activate the Python virtualenv needed by Ansible.
 if [[ ! -d venv/ ]]; then
-  virtualenv -p /usr/bin/python2.7 venv
+  virtualenv -p $(which python2) venv
 fi
 source venv/bin/activate
 


### PR DESCRIPTION
Jenkins CLI traditional “Remoting” operation mode of the Jenkins command-line interface has been removed in 2.165. The option is no longer available in "Manage Jenkins > Configure Global Security > CLI"

Blog post: https://jenkins.io/blog/2019/02/17/remoting-cli-removed/
Pull Request: https://github.com/jenkinsci/jenkins/pull/3838